### PR TITLE
fix a typo on the homepage

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -279,7 +279,7 @@
                   <div class="col-md-5 col-sm-12">
                     <div class="promo-section__description">
                       <h2 class="promo-section__title">Flexible Layout</h2>
-                      <p class="lead">Theia's shell is based on <a href="https://phosphorjs.github.io/">PhosporJS</a>, 
+                      <p class="lead">Theia's shell is based on <a href="https://phosphorjs.github.io/">PhosphorJS</a>, 
                         which provides a solid foundation for dragable dock layouts.</p>
                     </div>
                   </div>


### PR DESCRIPTION
`Phospor` ➜ `Phosphor`