### PR TITLE
swap the navbar logo to svg

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -60,7 +60,7 @@
               <!-- Logo -->
               <div class="logo-wrap">
                 <a href="index.html" class="logo__link">
-                  <img class="logo logo--dark" src="img/logo-dark.png" alt="logo">
+                  <img class="logo logo--dark" src="img/logo-dark.svg" alt="logo">
                 </a>
               </div>
 


### PR DESCRIPTION
The png logo looks awful when scaled down in MS Edge, so it's better to use a smaller png or to just switch to svg

## ![logo-png](https://user-images.githubusercontent.com/3507758/45902713-5eae1f80-bdb5-11e8-8972-d32df4db7837.PNG) &nbsp; &nbsp; ➜ &nbsp; &nbsp; ![logo-svg](https://user-images.githubusercontent.com/3507758/45902714-5f46b600-bdb5-11e8-8257-3b4763584209.PNG)
