### PR TITLE
actually add textmate page

### DIFF
--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -14,6 +14,7 @@
 * [Authoring an Extension](Authoring_Extensions.md)
 * [Authoring Plug-ins](Authoring_Plugins.md)
 * [Adding Language Support](Language_Support.md)
+  * [TextMate Coloring](TextMate.md)
 
 ## Concepts APIs
 


### PR DESCRIPTION
It seems that a page should be referenced from the TOC to be really published.