### PR TITLE
Fix strange features-anchor bug

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -189,7 +189,7 @@
           </section>
 
           <!-- Feature -->
-      <a name="features" />
+      <a name="features"></a>
       <section class="section-wrap" style="background-color: #fff;">
         <div class="container">
           <div class="row">
@@ -231,7 +231,7 @@
             <div class="col-sm-4 mb-sm-40">
                 <div class="feature">
                   <div class="feature__icon-holder">
-                    <img src="img/vscode.svg" class="feature__icon feature__icon--gradient" alt="VS Code" />
+                    <img src="img/vscode.svg" class="feature__icon feature__icon--gradient" alt="VS Code">
                   </div>
                   <div class="feature__text">
                     <h3 class="feature__title">VS Code Powered</h3>


### PR DESCRIPTION
For some reason, the features paragraph has many elements that get wrapped in `<a name="features"></a>` tags.

I'm not sure why, but this change fixes it.

Currently live:
<img width="357" alt="screenshot 2019-03-06 at 15 55 26" src="https://user-images.githubusercontent.com/599268/53890365-62162a00-4028-11e9-8e2a-0fb858f68902.png">

With this change:
<img width="360" alt="screenshot 2019-03-06 at 15 54 49" src="https://user-images.githubusercontent.com/599268/53890389-6b06fb80-4028-11e9-8af9-a34097a5ebac.png">

The bug seems to pre-date my recent changes, but I think my `a/div` replacement made it surface again.