### PR TITLE
SEO: Add canonical link

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -8,6 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Theia is an open-source cloud &nbsp; desktop IDE framework implemented in TypeScript.">
   <meta name="theme-color" content="#FFFFFF">
+  <link rel="canonical" href="https://www.theia-ide.org/">
 
   <!-- Google Fonts -->
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700%7CLato:300,400,400i,700' rel='stylesheet'>


### PR DESCRIPTION
The same Theia website is served under at least two URLs:
- https://www.theia-ide.org/
- https://www.theia-ide.org/index.html

This usually results in severe SEO downgrades from search engines like Google.

The good news is that it's pretty easy to fix.