### PR TITLE
/doc to /docs redirect rules

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+redirects = [
+    {from = "/doc", to = "/docs", status = 301},
+    {from = "/doc/*", to = "/docs/:splat", status = 301}]


### PR DESCRIPTION
Addresses #38 

This PR adds a [netlify.toml](https://www.netlify.com/docs/netlify-toml-reference/) file to the root of the project in order to re-direct traffic from `/doc` to `/docs`. This netlify.toml file can used to setup more redirect rules in the future, in addition to other things like build/deploy configurations, headers, etc.