### PR TITLE
Update links after org move

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Theia's Website
 [![setup automated](https://img.shields.io/badge/setup-automated-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
 
-The source for the [website](http://www.theia-ide.org) and [online documentation](http://www.theia-ide.org/docs) for the [Theia IDE Framework](https://github.com/theia-ide/theia).
+The source for the [website](http://www.theia-ide.org) and [online documentation](http://www.theia-ide.org/docs) for the [Theia IDE Framework](https://github.com/eclipse-theia/theia).
 
 ## How to contribute
 
@@ -17,4 +17,4 @@ npm install && npm run start --host 0.0.0.0
 
 ## CI
 
-The website is automatically build at and deployed to netlify. 
+The website is automatically build at and deployed to netlify.

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -45,7 +45,7 @@ const Footer = ({background}) => (
                 <a href="https://twitter.com/theia_ide" target="_blank" rel="noopener noreferrer" className="footer__link">
                     <img src={TwitterLogo} alt="Twitter Logo" className="footer__icon" />
                 </a>
-                <a href="https://github.com/theia-ide/theia" target="_blank" rel="noopener noreferrer" className="footer__link">
+                <a href="https://github.com/eclipse-theia/theia" target="_blank" rel="noopener noreferrer" className="footer__link">
                     <img src={GithubLogo} alt="Github Logo" className="footer__icon" />
                 </a>
                 <a href="https://spectrum.chat/theia" target="_blank" rel="noopener noreferrer" className="footer__link">

--- a/src/docs/Authoring_Plugins.mdx
+++ b/src/docs/Authoring_Plugins.mdx
@@ -40,7 +40,7 @@ A Theia app is composed of a core providing a set of widgets, commands, handlers
 Theia defines a runtime API allowing plug-ins to customize the IDE and add their behaviour to various aspects of the application.
 
 In Theia, a plug-in has access to the API through an object named `theia` which is available in all plug-ins.
-[More details on API](https://github.com/theia-ide/theia/blob/master/packages/plugin/README.md).
+[More details on API](https://github.com/eclipse-theia/theia/blob/master/packages/plugin/README.md).
 
 There are two natures of plug-ins:
  - Backend plug-in. If you're familiar with VS Code extensions, it's very close. The plug-in's code is running in its own process on the server side. API is called and it's the API that will send some actions on user's browser/UI to register new commands, etc. All the callbacks are executed on the server side on a dedicated process.
@@ -49,7 +49,7 @@ There are two natures of plug-ins:
 ## Prerequisites
 
 Having a running Theia instance. (v0.3.12+)
-Instructions for getting Theia are available from [Theia repository](https://github.com/theia-ide/theia#getting-started).
+Instructions for getting Theia are available from [Theia repository](https://github.com/eclipse-theia/theia#getting-started).
 
 ## Project Layout
 
@@ -198,7 +198,7 @@ Then you'll only have to refresh the tab of the `Development Host` instance, the
 Note: you may use watch mode as well.
 
 ## API of plug-ins
-[Browse typedoc of plug-ins](https://theia-ide.github.io/theia/docs/next/modules/plugin.__theia_plugin_-1.html)
+[Browse typedoc of plug-ins](https://eclipse-theia.github.io/theia/docs/next/modules/plugin.__theia_plugin_-1.html)
 
 ## VS Code implementation
 Theia is providing VS Code API. Check the following link to get the current status of what is implemented.

--- a/src/docs/Json_Rpc.mdx
+++ b/src/docs/Json_Rpc.mdx
@@ -345,7 +345,7 @@ container.load(frontendLanguagesModule);
 ## Complete example
 
 If you wish to see the complete implementation of what I referred too in
-this documentation see [this commit](https://github.com/theia-ide/theia/commit/99d191f19bd2a3e93098470ca1bb7b320ab344a1).
+this documentation see [this commit](https://github.com/eclipse-theia/theia/commit/99d191f19bd2a3e93098470ca1bb7b320ab344a1).
 
 
 <DocArrowNavigators prev="events" />

--- a/src/docs/README.mdx
+++ b/src/docs/README.mdx
@@ -7,12 +7,12 @@ import DocImage from 'components/DocImage'
 import DocArrowNavigators from 'components/DocArrowNavigators'
 
 # Theia - Cloud & Desktop IDE
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://github.com/theia-ide/theia/labels/help%20wanted)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://github.com/eclipse-theia/theia/labels/help%20wanted)
 [![Community](https://img.shields.io/badge/chat-on%20spectrum-blue.svg)](https://spectrum.chat/theia)
-[![Build Status](https://travis-ci.org/theia-ide/theia.svg?branch=master)](https://travis-ci.org/theia-ide/theia)
+[![Build Status](https://travis-ci.org/eclipse-theia/theia.svg?branch=master)](https://travis-ci.org/eclipse-theia/theia)
 [![Build status](https://ci.appveyor.com/api/projects/status/02s4d40orokl3njl/branch/master?svg=true)](https://ci.appveyor.com/project/kittaakos/theia/branch/master)
-[![Open questions](https://img.shields.io/badge/Open-questions-pink.svg?style=flat-square)](https://github.com/theia-ide/theia/labels/question)
-[![Open bugs](https://img.shields.io/badge/Open-bugs-red.svg?style=flat-square)](https://github.com/theia-ide/theia/labels/bug)
+[![Open questions](https://img.shields.io/badge/Open-questions-pink.svg?style=flat-square)](https://github.com/eclipse-theia/theia/labels/question)
+[![Open bugs](https://img.shields.io/badge/Open-bugs-red.svg?style=flat-square)](https://github.com/eclipse-theia/theia/labels/bug)
 
 Theia is an extensible platform to develop full-fledged multi-language Cloud & Desktop IDE-like products with state-of-the-art web technologies.
 
@@ -28,24 +28,24 @@ Theia is an extensible platform to develop full-fledged multi-language Cloud & D
 ## Contributing
 
 Read below to learn how to take part in improving Theia:
-- Fork the repository and [run the examples from source](https://github.com/theia-ide/theia/tree/master/doc/Developing.md#quick-start)
-- Get familiar with [the development workflow](https://github.com/theia-ide/theia/tree/master/doc/Developing.md), [Coding Guidelines](https://github.com/theia-ide/theia/wiki/Coding-Guidelines), [Code of Conduct](https://github.com/theia-ide/theia/tree/master/CODE_OF_CONDUCT.md) and [learn how to sign your work](https://github.com/theia-ide/theia/tree/master/CONTRIBUTING.md#sign-your-work)
+- Fork the repository and [run the examples from source](https://github.com/eclipse-theia/theia/tree/master/doc/Developing.md#quick-start)
+- Get familiar with [the development workflow](https://github.com/eclipse-theia/theia/tree/master/doc/Developing.md), [Coding Guidelines](https://github.com/eclipse-theia/theia/wiki/Coding-Guidelines), [Code of Conduct](https://github.com/eclipse-theia/theia/tree/master/CODE_OF_CONDUCT.md) and [learn how to sign your work](https://github.com/eclipse-theia/theia/tree/master/CONTRIBUTING.md#sign-your-work)
 - Find an issue to work on and submit a pull request
-  - First time contributing to open source? Pick a [good first issue](https://github.com/theia-ide/theia/labels/good%20first%20issue) to get you familiar with GitHub contributing process.
-  - First time contributing to Theia? Pick a [beginner friendly issue](https://github.com/theia-ide/theia/labels/beginners) to get you familiar with codebase and our contributing process.
-  - Want to become a Committer? Solve an issue showing that you understand Theia objectives and architecture. [Here](https://github.com/theia-ide/theia/labels/help%20wanted) is a good list to start.
+  - First time contributing to open source? Pick a [good first issue](https://github.com/eclipse-theia/theia/labels/good%20first%20issue) to get you familiar with GitHub contributing process.
+  - First time contributing to Theia? Pick a [beginner friendly issue](https://github.com/eclipse-theia/theia/labels/beginners) to get you familiar with codebase and our contributing process.
+  - Want to become a Committer? Solve an issue showing that you understand Theia objectives and architecture. [Here](https://github.com/eclipse-theia/theia/labels/help%20wanted) is a good list to start.
 - Could not find an issue? Look for bugs, typos, and missing features.
 
 ## Feedback
 
 Read below how to engage with Theia community:
 - Join the discussion on [Spectrum](https://spectrum.chat/theia).
-- Ask a question, request a new feature and file a bug with [GitHub issues](https://github.com/theia-ide/theia/issues/new).
+- Ask a question, request a new feature and file a bug with [GitHub issues](https://github.com/eclipse-theia/theia/issues/new).
 - Star the repository to show your support.
 - Follow Theia on [Twitter](https://twitter.com/theia_ide).
 
 ## License
 
-[Apache-2.0](https://github.com/theia-ide/theia/blob/master/LICENSE)
+[Apache-2.0](https://github.com/eclipse-theia/theia/blob/master/LICENSE)
 
 <DocArrowNavigators next='architecture'/>

--- a/src/docs/Services_and_Contributions.mdx
+++ b/src/docs/Services_and_Contributions.mdx
@@ -51,7 +51,7 @@ when needed.
 
 The `OpenerService`, for instance, defines a contribution point to allow others
 registering `OpenHandler`s. You can have a look at the code
-[here](https://github.com/theia-ide/theia/blob/master/packages/core/src/browser/opener-service.ts).
+[here](https://github.com/eclipse-theia/theia/blob/master/packages/core/src/browser/opener-service.ts).
 
 Theia comes with an extensive list of contribution points already. A good way
 to see what contribution points exist is to do a find references on

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -335,12 +335,12 @@ export default () => {
                             <h2 className="heading-tertiary" style={{ fontSize: '2.2rem' }}>
                                 Eclipse Theia is an extensible platform to develop multi-language Cloud & Desktop IDEs with state-of-the-art web technologies.
                             </h2>
-                            <a className="btn" href="https://github.com/theia-ide/theia" target="_blank" rel="noopener noreferrer">View on GitHub</a>
-                            <a className="btn btn--cta" href="https://gitpod.io#https://github.com/theia-ide/theia" target="_blank" rel="noopener">Try in Gitpod &nbsp;&nbsp;&rarr;</a>
+                            <a className="btn" href="https://github.com/eclipse-theia/theia" target="_blank" rel="noopener noreferrer">View on GitHub</a>
+                            <a className="btn btn--cta" href="https://gitpod.io#https://github.com/eclipse-theia/theia" target="_blank" rel="noopener">Try in Gitpod &nbsp;&nbsp;&rarr;</a>
                         </div>
                         <div className="header__github-details">
-                            <iframe title="Github Star Count" className="header__github-button" src="https://ghbtns.com/github-btn.html?user=theia-ide&repo=theia&type=star&count=true" frameBorder={0} scrolling={0} />
-                            <iframe title="Github Fork Count" className="header__github-button" src="https://ghbtns.com/github-btn.html?user=theia-ide&repo=theia&type=fork&count=true" frameBorder={0} scrolling={0} />
+                            <iframe title="Github Star Count" className="header__github-button" src="https://ghbtns.com/github-btn.html?user=eclipse-theia&repo=theia&type=star&count=true" frameBorder={0} scrolling={0} />
+                            <iframe title="Github Fork Count" className="header__github-button" src="https://ghbtns.com/github-btn.html?user=eclipse-theia&repo=theia&type=fork&count=true" frameBorder={0} scrolling={0} />
                         </div>
                     </div>
 


### PR DESCRIPTION
Update the links from `theia-ide` to `eclipse-theia`.

Based on [comment](https://github.com/eclipse-theia/theia/issues/6182) from the main repo.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>