### PR TITLE
[docs] remove reference and badge to AppVeyor

### DIFF
--- a/src/docs/README.mdx
+++ b/src/docs/README.mdx
@@ -10,7 +10,6 @@ import DocArrowNavigators from 'components/DocArrowNavigators'
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://github.com/eclipse-theia/theia/labels/help%20wanted)
 [![Community](https://img.shields.io/badge/chat-on%20spectrum-blue.svg)](https://spectrum.chat/theia)
 [![Build Status](https://travis-ci.org/eclipse-theia/theia.svg?branch=master)](https://travis-ci.org/eclipse-theia/theia)
-[![Build status](https://ci.appveyor.com/api/projects/status/02s4d40orokl3njl/branch/master?svg=true)](https://ci.appveyor.com/project/kittaakos/theia/branch/master)
 [![Open questions](https://img.shields.io/badge/Open-questions-pink.svg?style=flat-square)](https://github.com/eclipse-theia/theia/labels/question)
 [![Open bugs](https://img.shields.io/badge/Open-bugs-red.svg?style=flat-square)](https://github.com/eclipse-theia/theia/labels/bug)
 


### PR DESCRIPTION
Fixes #63

Description:

- Remove the reference and badge to `AppVeyor` since
the CI integration no longer exists in the main repository as
of https://github.com/eclipse-theia/theia/pull/6179.

Additional Info

- The badge displayed an old build which was failing meaning
the failed state would always be displayed unless the badge
is removed.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>