### PR TITLE
Added semantic titles and aria-labels to Navigation arrows in the docs for better UX and a11y.

### DIFF
--- a/src/components/DocArrowNavigators.js
+++ b/src/components/DocArrowNavigators.js
@@ -22,15 +22,19 @@ const Styled = styled.div`
     }
 `
 
-const DocArrowNavigators = ({prev, next}) => (
+const DocArrowNavigators = ({prev, next, prevTitle, nextTitle}) => {
+    const pTitle = `Go to previous Page ${prevTitle ? `: ${prevTitle}` : ""}`
+    const nTitle = `Go to next page ${nextTitle ? `: ${nextTitle}` : ""}`
+    return (
     <Styled>
-        <Link to={`/docs/${prev}`} style={{pointerEvents: !prev && 'none' }}>
-            <img src={Arrow} alt="Prev Page" className="arrow arrow--left" style={{opacity: !prev ? '.3' : 1}}/>
+        <Link to={`/docs/${prev}`} title={pTitle} aria-label={pTitle} style={{pointerEvents: !prev && 'none' }}>
+            <img src={Arrow} alt={pTitle} className="arrow arrow--left" style={{opacity: !prev ? '.3' : 1}}/>
         </Link>
-        <Link to={`/docs/${next}`} alt="Next Page" style={{pointerEvents: !next && 'none' }}>
-            <img src={Arrow} alt="Next Page" className="arrow arrow--right" style={{opacity: !next ? '.3' : 1}} />
+        <Link to={`/docs/${next}`} title={nTitle} aria-label={nTitle} style={{pointerEvents: !next && 'none' }}>
+            <img src={Arrow} alt={nTitle} className="arrow arrow--right" style={{opacity: !next ? '.3' : 1}} />
         </Link>
     </Styled>
 )
+}
 
 export default DocArrowNavigators

--- a/src/docs/Architecture.mdx
+++ b/src/docs/Architecture.mdx
@@ -61,4 +61,4 @@ For a high level overview of Theia's Architecture, see this document:
 
 [Multi-Language IDE Implemented in JS - Scope and Architecture](https://docs.google.com/document/d/1aodR1LJEF_zu7xBis2MjpHRyv7JKJzW7EWI9XRYCt48)
 
-<DocArrowNavigators prev='index' next='extensions'/>
+<DocArrowNavigators prev='index' prevTitle="Intro" next='extensions' nextTitle='Extensions'/>

--- a/src/docs/Authoring_Extensions.mdx
+++ b/src/docs/Authoring_Extensions.mdx
@@ -248,4 +248,4 @@ yarn start <path to workspace>
 
 If you want to make your extension publicly available, we recommend to publish it to npm. This can be achieved by calling `yarn publish` from the extension package's directory. Of course you need a valid account for that.
 
-<DocArrowNavigators prev="composing_applications" next="authoring_plugins"/>
+<DocArrowNavigators prev="composing_applications" prevTitle="Build your own IDE" next="authoring_plugins" nextTitle="Authoring Plug-ins"/>

--- a/src/docs/Authoring_Plugins.mdx
+++ b/src/docs/Authoring_Plugins.mdx
@@ -205,4 +205,4 @@ Theia is providing VS Code API. Check the following link to get the current stat
 [Compare Theia vs VS Code API](https://che-incubator.github.io/vscode-theia-comparator/status.html)
 
 
-<DocArrowNavigators prev="authoring_extensions" next="language_support"/>
+<DocArrowNavigators prev="authoring_extensions" prevTitle="Authoring Extensions" next="language_support" nextTitle="Adding Language Support"/>

--- a/src/docs/Commands_Keybindings.mdx
+++ b/src/docs/Commands_Keybindings.mdx
@@ -123,4 +123,4 @@ export default new ContainerModule(bind => {
 });
 
 ```
-<DocArrowNavigators prev="textmate" next="preferences"/>
+<DocArrowNavigators prev="textmate" prevTitle="TextMate Coloring" next="preferences" nextTitle="Preferences"/>

--- a/src/docs/Composing_Applications.mdx
+++ b/src/docs/Composing_Applications.mdx
@@ -146,4 +146,4 @@ This happens because node-gyp does not rely on system/NPM proxy settings. In tha
 
      npm_config_tarball=/path/to/node-v8.15.0-headers.tar.gz yarn install
 
-<DocArrowNavigators prev="services_and_contributions" next="authoring_extensions"/>
+<DocArrowNavigators prev="services_and_contributions" prevTitle="Services and Contributions" next="authoring_extensions" nextTitle="Authoring Theia Extensions"/>

--- a/src/docs/Events.mdx
+++ b/src/docs/Events.mdx
@@ -93,4 +93,4 @@ So if you need to trigger events in theia:
  - Register events with the emitter.event function
  - Fire events with emitter.fire(event)
 
-<DocArrowNavigators prev="preferences" next="json_rpc"/>
+<DocArrowNavigators prev="preferences" prevTitle="Preferences" next="json_rpc" nextTitle="Communication via JSON-RPC"/>

--- a/src/docs/Extensions.mdx
+++ b/src/docs/Extensions.mdx
@@ -19,4 +19,4 @@ runtime, which will trigger a recompilation and restart.
 Through a DI module, the extension can provide bindings from types to concrete
 implementations, i.e. provide services and contributions.
 
-<DocArrowNavigators prev='architecture' next='services_and_contributions'/>
+<DocArrowNavigators prev='architecture' prevTitle="Architecture Overview" next='services_and_contributions' nextTitle="Services and Contributions"/>

--- a/src/docs/Json_Rpc.mdx
+++ b/src/docs/Json_Rpc.mdx
@@ -348,5 +348,5 @@ If you wish to see the complete implementation of what I referred too in
 this documentation see [this commit](https://github.com/eclipse-theia/theia/commit/99d191f19bd2a3e93098470ca1bb7b320ab344a1).
 
 
-<DocArrowNavigators prev="events" />
+<DocArrowNavigators prev="events" prevTitle="Events"/>
 

--- a/src/docs/Language_Support.mdx
+++ b/src/docs/Language_Support.mdx
@@ -10,4 +10,4 @@ import DocArrowNavigators from 'components/DocArrowNavigators'
 
 * <Link to="/docs/textmate">TextMate Coloring</Link>
 
-<DocArrowNavigators prev="authoring_plugins" next="textmate"/>
+<DocArrowNavigators prev="authoring_plugins" prevTitle="Authoring Plugins" next="textmate"  nextTitle="TextMate Coloring"/>

--- a/src/docs/Preferences.mdx
+++ b/src/docs/Preferences.mdx
@@ -42,7 +42,7 @@ export interface PreferenceContribution {
 }
 ```
 
-For instance, the filesystem binds it like so : 
+For instance, the filesystem binds it like so:
 ```typescript
 export const filesystemPreferenceSchema: PreferenceSchema = {
     "type": "object",
@@ -57,8 +57,8 @@ export const filesystemPreferenceSchema: PreferenceSchema = {
 };
 
 bind(PreferenceContribution).toConstantValue(
-{ 
-    schema: filesystemPreferenceSchema 
+{
+    schema: filesystemPreferenceSchema
 });
 ```
 
@@ -180,7 +180,7 @@ In the case of the filesystem, one would use the same proxied config as above to
     if (this.prefService['preferenceName']) {
     ...
     }
-    
+
     if (this.prefService['preferenceName2']) {
     ...
     }
@@ -194,4 +194,4 @@ This works because, as we have seen it above, the proxy will simply call prefSer
 * Add autocomplete/description when modifying the settings.json from within theia
 
 
-<DocArrowNavigators prev="commands_keybindings" next="events"/>
+<DocArrowNavigators prev="commands_keybindings" prevTitle="Commands & Keybindings" next="events" nextTitle="Events"/>

--- a/src/docs/README.mdx
+++ b/src/docs/README.mdx
@@ -48,4 +48,4 @@ Read below how to engage with Theia community:
 
 [Apache-2.0](https://github.com/eclipse-theia/theia/blob/master/LICENSE)
 
-<DocArrowNavigators next='architecture'/>
+<DocArrowNavigators next='architecture' nextTitle="Architecture Overview"/>

--- a/src/docs/Services_and_Contributions.mdx
+++ b/src/docs/Services_and_Contributions.mdx
@@ -94,4 +94,4 @@ ConnectionHandler value that was bound before by `bindContributionProvider`.
 This enables anyone to bind a ConnectionHandler and now when the
 messagingModule is started all the ConnectionHandlers will be initiated.
 
-<DocArrowNavigators prev="extensions" next="composing_applications"/>
+<DocArrowNavigators prev="extensions" prevTitle="Extensions" next="composing_applications" nextTitle="Build your own IDE"/>

--- a/src/docs/TextMate.mdx
+++ b/src/docs/TextMate.mdx
@@ -101,4 +101,4 @@ export class YourContribution implements LanguageGrammarDefinitionContribution {
     }
 }
 ```
-<DocArrowNavigators prev="language_support" next="commands_keybindings"/>
+<DocArrowNavigators prev="language_support" prevTitle="Language Support" next="commands_keybindings" nextTitle="Commands and Keybindings"/>


### PR DESCRIPTION
For accessibility reasons, all Links must have a discernible text(name). 

![image](https://user-images.githubusercontent.com/46004116/67924442-78ce4a00-fbd2-11e9-8133-c60cfb776052.png)

but here for Navigation arrows  Docs. we're using images inside of the link without any label or title on the links.
This PR adds semantic aria-labels and title to the wrapper links.

Now with this change in place if the user is to hover on the arrow due to the added title attribute it shows this:

![image](https://user-images.githubusercontent.com/46004116/67924735-38bb9700-fbd3-11e9-820b-10d573d0b0cf.png)

which in my opinion is kind of better user experience :slightly_smiling_face: 

