### PR TITLE
docs: update license link name

### DIFF
--- a/src/docs/README.mdx
+++ b/src/docs/README.mdx
@@ -45,6 +45,6 @@ Read below how to engage with Theia community:
 
 ## License
 
-[Apache-2.0](https://github.com/eclipse-theia/theia/blob/master/LICENSE)
+[EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0](https://github.com/eclipse-theia/theia/blob/master/LICENSE)
 
 <DocArrowNavigators next='architecture' nextTitle="Architecture Overview"/>


### PR DESCRIPTION
Fixes #81

The pull-request updates the license link name. The link itself points to the `theia` main repo's license but still uses Apache 2.0 instead of the correct license EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0. This pull-request addresses that issue so there is no longer any confusion.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>