### PR TITLE
docs: fix generator-theia-extension command

### DIFF
--- a/src/docs/Authoring_Extensions.mdx
+++ b/src/docs/Authoring_Extensions.mdx
@@ -44,7 +44,7 @@ To ease the setup of such a repository we have created a [code generator](https:
 npm install -g yo generator-theia-extension
 mkdir theia-hello-world-extension
 cd theia-hello-world-extension
-yo theia-extension hello-world-extension
+yo theia-extension # select the 'Hello World' option and complete the prompts
 ```
 
 Let's have look at the generated code now. The root `package.json` defines the workspaces, the dependency to `lerna` and some scripts to rebuild the native packages for browser or electron.


### PR DESCRIPTION
Fixes #75

The pull-request updates the documentation for generating the `hello-world` example when using the `generator-theia-extension`.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>