### PR TITLE
docs: update the prerequisites information

### DIFF
--- a/src/docs/Authoring_Extensions.mdx
+++ b/src/docs/Authoring_Extensions.mdx
@@ -19,20 +19,7 @@ In Theia, everything is wired up via [dependency injection](Services_and_Contrib
 
 ## Prerequisites
 
-You’ll need node in version 10:
-
-```bash
-curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
-nvm install 10
-```
-
-and yarn
-
-```
-npm install -g yarn
-```
-
-Also make sure your `python --version` points to a Python 2.x installation.
+Prerequisites information are available from the [Theia repository](https://github.com/eclipse-theia/theia/blob/master/doc/Developing.md#prerequisites).
 
 ## Project Layout
 


### PR DESCRIPTION
Fixes #29

Updates information regarding `prerequisites` by pointing to the source of truth
located at the main repository's `Developing.md#prerequisites` section. The prerequisites described in the main repo are also more complete and up-to-date.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>