### PR TITLE
docs: remove deprecated extensions

### DIFF
--- a/src/docs/Authoring_Extensions.mdx
+++ b/src/docs/Authoring_Extensions.mdx
@@ -194,7 +194,6 @@ Now we want to see our extension in action. For this purpose, the generator has 
     "@theia/languages": "latest",
     "@theia/markers": "latest",
     "@theia/monaco": "latest",
-    "@theia/typescript": "latest",
     "@theia/messages": "latest",
     "hello-world-extension": "0.1.0"
   },

--- a/src/docs/Composing_Applications.mdx
+++ b/src/docs/Composing_Applications.mdx
@@ -40,23 +40,20 @@ Create `package.json` in this directory:
 {
   "private": true,
   "dependencies": {
-    "typescript": "latest",
-    "@theia/typescript": "next",
-    "@theia/navigator": "next",
-    "@theia/terminal": "next",
-    "@theia/outline-view": "next",
-    "@theia/preferences": "next",
-    "@theia/messages": "next",
-    "@theia/git": "next",
-    "@theia/file-search": "next",
-    "@theia/markers": "next",
-    "@theia/preview": "next",
     "@theia/callhierarchy": "next",
-    "@theia/merge-conflicts": "next",
-    "@theia/search-in-workspace": "next",
+    "@theia/file-search": "next",
+    "@theia/git": "next",
     "@theia/json": "next",
-    "@theia/textmate-grammars": "next",
-    "@theia/mini-browser": "next"
+    "@theia/markers": "next",
+    "@theia/messages": "next",
+    "@theia/mini-browser": "next",
+    "@theia/navigator": "next",
+    "@theia/outline-view": "next",
+    "@theia/plugin-ext-vscode": "next",
+    "@theia/preferences": "next",
+    "@theia/preview": "next",
+    "@theia/search-in-workspace": "next",
+    "@theia/terminal": "next"
   },
   "devDependencies": {
     "@theia/cli": "next"
@@ -77,6 +74,57 @@ Let's have a look at the created package:
     In such cases, please consult the corresponding extension documentation.
     - Use [this link](https://www.npmjs.com/search?q=keywords:theia-extension) too see all published extensions.
   - We've listed [@theia/cli](https://www.npmjs.com/package/@theia/cli) as a build-time dependency. It provides scripts to build and run the application.
+
+## Consuming VS Code Extensions
+
+As part of your application, it is also possible to consume (and package) VS Code extensions.
+The [Theia repository](https://github.com/eclipse-theia/theia/wiki/Consuming-Builtin-and-External-VS-Code-Extensions) contains a guide on how to
+include such extensions as part of the application's `package.json`.
+
+An example `package.json` may look like the following:
+
+```json
+{
+  "private": true,
+  "dependencies": {
+    "@theia/callhierarchy": "next",
+    "@theia/file-search": "next",
+    "@theia/git": "next",
+    "@theia/json": "next",
+    "@theia/markers": "next",
+    "@theia/messages": "next",
+    "@theia/mini-browser": "next",
+    "@theia/navigator": "next",
+    "@theia/outline-view": "next",
+    "@theia/plugin-ext-vscode": "next",
+    "@theia/preferences": "next",
+    "@theia/preview": "next",
+    "@theia/search-in-workspace": "next",
+    "@theia/terminal": "next"
+  },
+  "devDependencies": {
+    "@theia/cli": "next"
+  },
+  "scripts": {
+    "prepare": "yarn run clean && yarn build && yarn run download:plugins",
+    "clean": "theia clean",
+    "build": "theia build --mode development",
+    "download:plugins": "theia download:plugins"
+  },
+  "theiaPluginsDir": "plugins",
+  "theiaPlugins": {
+    "vscode-builtin-css": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/css-1.39.1-prel.vsix",
+    "vscode-builtin-html": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/html-1.39.1-prel.vsix",
+    "vscode-builtin-javascript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/javascript-1.39.1-prel.vsix",
+    "vscode-builtin-json": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/json-1.39.1-prel.vsix",
+    "vscode-builtin-markdown": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/markdown-1.39.1-prel.vsix",
+    "vscode-builtin-npm": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/npm-1.39.1-prel.vsix",
+    "vscode-builtin-scss": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/scss-1.39.1-prel.vsix",
+    "vscode-builtin-typescript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/typescript-1.39.1-prel.vsix",
+    "vscode-builtin-typescript-language-features": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/typescript-language-features-1.39.1-prel.vsix"
+  }
+}
+```
 
 ## Building
 


### PR DESCRIPTION
Fixes #82

This pull-request:
- removes references to deprecated extensions from the docs
- adds a section in composing applications which references a guide present in the main repo regarding how to consume VS Code extensions.


Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>