### PR TITLE
website: add 'platform' to header to avoid confusion

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,6 @@
 module.exports = {
     siteMetadata: {
-        title: 'Theia - Cloud and Desktop IDE',
+        title: 'Theia - Cloud and Desktop IDE Platform',
         description: "Theia is an open-source cloud &nbsp; desktop IDE framework implemented in TypeScript."
     },
     plugins: [

--- a/src/components/index/Header.js
+++ b/src/components/index/Header.js
@@ -67,14 +67,14 @@ const Header = () => (
                         <img className="header__logo" src={TheiaLogoDark} alt="theia logo" />
                     </div>
                     <h1 className="heading-primary">
-                        Cloud & Desktop IDE
+                        Cloud & Desktop IDE Platform
                 </h1>
                     <h2 className="heading-tertiary" style={{ fontSize: '2.2rem' }}>
                         Eclipse Theia is an extensible platform to develop multi-language Cloud & Desktop IDEs with state-of-the-art web technologies.
                         <br/>
                         <a href="https://dev.to/svenefftinge/theia-1-0-finally-a-good-browser-ide-3ok0">Learn about the 1.0 Release!</a>
                     </h2>
-                    
+
                     <a className="btn" href="https://github.com/eclipse-theia/theia" target="_blank" rel="noopener noreferrer">View on GitHub</a>
                     <a className="btn btn--cta" href="https://gitpod.io/#https://github.com/eclipse-theia/theia" target="_blank" rel="noopener">Try in Gitpod &nbsp;&nbsp;&rarr;</a>
                 </div>
@@ -94,4 +94,4 @@ const Header = () => (
     </StyledHeader>
 )
 
-export default Header 
+export default Header


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #62

- The following pull-request updates the website's header (to include **platform**) in order to be explicit and avoid any potential confusion adopters/users might have about the software. Currently, we only use **Cloud & Desktop IDE** as a header which is incorrect and does not accurately describe the software.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

The header and browser tab title should be updated to more explicitly describe the software.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>